### PR TITLE
Added GET request support for posts data, based on user id

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,9 +30,13 @@ class RareApi(RequestHandler):
             response = Category().get_all()
             return self.response(response, status.HTTP_200_SUCCESS)
         elif url["requested_resource"] == "posts":
-            print("Fetching posts...")
-            response_body = Post().list_posts()
-            return self.response(json.dumps(response_body), status.HTTP_200_SUCCESS)
+            if "user_id" in url["query_params"]:
+                response_body = Post().get_user_posts(url["query_params"])
+                return self.response(response_body, status.HTTP_200_SUCCESS)
+            else:
+                print("Fetching posts...")
+                response_body = Post().list_posts()
+                return self.response(json.dumps(response_body), status.HTTP_200_SUCCESS)
 
     def do_POST(self):
         """Handle POST requests from client"""

--- a/views/posts.py
+++ b/views/posts.py
@@ -1,5 +1,5 @@
 import sqlite3
-
+import json
 
 class Post:
     
@@ -51,4 +51,36 @@ class Post:
             posts = [dict(row) for row in query_results]
 
         return posts
-            
+
+    def get_user_posts(self, query_params):
+        with sqlite3.connect("./db.sqlite3") as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            user_id = int(query_params["user_id"][0])
+            db_cursor.execute(
+                """
+                SELECT
+                    p.id,
+                    p.user_id,
+                    p.category_id,
+                    p.title,
+                    p.publication_date,
+                    p.image_url,
+                    p.content,
+                    p.approved
+                FROM Posts p
+                WHERE p.user_id = ?
+                """, (user_id,)
+            )
+
+            query_results = db_cursor.fetchall()
+
+            user_posts = []
+
+            for result in query_results:
+                user_posts.append(dict(result))
+
+            user_posts_json = json.dumps(user_posts)
+
+            return user_posts_json
+        


### PR DESCRIPTION
**What**
According to our requirements, the web application that we are developing needs a page that a logged in user may view the posts they have created. This is the first half of developing that functionality for them. Our server now supports retrieving posts based on a user's id.

**Why**
This functionality is needed because a user has not created all possible posts, they have posted only a fraction of the total posts. Now, through the query parameters that are received in this GET command, a user can retrieve and view only the posts that they have made. 

**How do I test this?**
1. Ensure that you have created some posts, logged in as one user.
2. Create a new user, and create a few more posts.
3. All of the posts from user one and user two are now submitted into the database, the rest will have to be performed with Postman
4. In Postman, set the HTTP command to GET.
5. Enter a URL with the endpoint `/posts`. This is the required table in the database.
6. Add some query parameters to your request. (i.e. "?user_id=1")
7. You will receive all of the posts created by the user number one
8. Try it with user number two, you will receive the posts they have created

**Issue**
This pull request aims to fulfill the requirements of issue ticket #11. According to this ticket, a future component "My Posts" will be built out in the front-end. The functionality created here is to support the development process of this component. 

**Files Changed**
Changed: `server.py` (lines 32 - 39) The else block was created in this pull request, but the code itself already existed.
Changed: `views/posts.py` (lines 55 - 85) This is the new method that executes the SQL query, returns are based on query parameter's value.  