### PR TITLE
Added expansion support for fetching post details

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -90,4 +90,7 @@ INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
 
 INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date', 'image_url', 'content','approved') 
-VALUES (1, 3, 'how to code', '2024-02-04', 'url.photo', 'coding', 'false')
+VALUES (1, 3, 'how to code', '2024-02-04', 'url.photo', 'coding', 'false');
+
+UPDATE Posts
+SET "image_url" = 'https://static.wikia.nocookie.net/pixar/images/7/79/Bookworm.png/12315';

--- a/server.py
+++ b/server.py
@@ -34,10 +34,13 @@ class RareApi(RequestHandler):
             if "user_id" in url["query_params"]:
                 response_body = Post().get_user_posts(url["query_params"])
                 return self.response(response_body, status.HTTP_200_SUCCESS)
+            elif "post_id" in url["query_params"]:
+                response_body = Post().get_post_by_id(url["query_params"])
+                return self.response(response_body, status.HTTP_200_SUCCESS)
             else:
                 response_body = Post().list_posts()
                 return self.response(json.dumps(response_body), status.HTTP_200_SUCCESS)
-
+            
         elif url["requested_resource"] == "user-fullname":
             response_body = "User not Found"
             if "user_id" in url["query_params"]:

--- a/views/posts.py
+++ b/views/posts.py
@@ -89,12 +89,11 @@ class Post:
                     p.publication_date,
                     p.image_url,
                     p.content,
-                    p.approved,
-                    p.created_at
+                    p.approved
                 FROM Posts p
+                JOIN Users u
+                ON p.user_id = u.id                
                 WHERE p.user_id = ?
-                    JOIN Users u
-                    ON p.user_id = u.id                
                 """, (user_id,)
             )
 


### PR DESCRIPTION


What
Support has been added to retrieve more information about a post by adding join tables to the SQL queries.

Why
This data is relevant to what the client requires to display the relevant data to the user. This information will not be interfered with by the user directly, but is necessary when fetching already submitted data to the database.

How can I test this?
(Note: No expansion queries are needed, but may be added later. Other related data from other tables act as flat data).

In Postman, fetch for posts in general by the /posts endpoint, or with the query parameters for a specific post (i.e. ?post_id=).

Issue
This pull request aims to support the functionality required by issue ticket #13, which is a detailed view of each individual post that has been made
