### PR TITLE
Added second SQL query to return to the client the created post

### DIFF
--- a/server.py
+++ b/server.py
@@ -73,7 +73,7 @@ class RareApi(RequestHandler):
         if url["requested_resource"] == "posts":
             post_created = Post().create_post(request)
             if post_created:
-                return self.response("", status.HTTP_201_SUCCESS_CREATED)
+                return self.response(post_created, status.HTTP_201_SUCCESS_CREATED)
             else:
                 return self.response(
                     "Validation error",

--- a/views/posts.py
+++ b/views/posts.py
@@ -41,9 +41,32 @@ class Post:
                     post["approved"],
                 ),
             )
-            row_affected = db_cursor.rowcount
+            # row_affected = db_cursor.rowcount
 
-            return True if row_affected > 0 else False
+            # return True if row_affected > 0 else False
+
+            db_cursor.execute(
+                """ 
+                SELECT
+                    p.id,
+                    p.user_id,
+                    p.category_id,
+                    p.title,
+                    p.publication_date,
+                    p.image_url,
+                    p.content,
+                    p.approved
+                FROM Posts p
+                ORDER BY Id DESC
+                LIMIT 1
+                """
+            )
+
+            last_created_item = db_cursor.fetchone()
+
+            last_created_item_as_dictionary = dict(last_created_item)
+            last_created_item_as_json = json.dumps(last_created_item_as_dictionary)
+            return last_created_item_as_json
 
     def list_posts(self):
         """Get all posts from the database"""


### PR DESCRIPTION
**What**
The changes made in this pull request is a second SQL query string in the .create_post method. The purpose is to send back a usable response to the client so that once the post has been submitted, they client may navigated to the post's details page. 

**Why**
The .create_post method needed to be extended for this purpose. This is the method that directly deals with the current post's response body. Once the first SQL query executes, a new row is added to the database. Afterwards, the second SQL query retrieves the latest submission to the database and returns the whole post submitted in the response body to the client

**How can I test this?**
1. Ensure that your server is running
2. To test this part, you will need to also have Postman open
3. In Postman, switch HTTP commands to POST
4. Create a response body following the pattern of the data layout in the database.
5. Send the requested body to the server at this url `http://localhost:8088/posts`
6. You will receive the data that you requested to submit as response. 

**Issue**
The goal of this pull request is to fix the bug found in the `Create A Post` form. The requirements necessitate navigation after a post has been submitted. Therefore, the latest submitted post is required for this navigation. See issue ticket #40.

**Files Change**
Changed: `server.py` (line 76) Included response body
Changed: `views/posts.py` (lines 48 - 69) Second SQL query addition