### PR TITLE
Added DELETE support for API at `/posts` endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -126,6 +126,14 @@ class RareApi(RequestHandler):
 
     def do_DELETE(self):
         """Handle DELETE requests from client"""
+        url = self.parse_url(self.path)
+
+        if url["requested_resource"] == "posts":
+            if url["pk"]:
+                response = Post().delete_a_post(int(url["pk"]))
+                return self.response("", status.HTTP_200_SUCCESS)
+            else:
+                return self.response("", status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA)
         return self.response(
             "Not Implemented", status.HTTP_501_SERVER_ERROR_NOT_IMPLEMENTED
         )

--- a/server.py
+++ b/server.py
@@ -130,7 +130,7 @@ class RareApi(RequestHandler):
 
         if url["requested_resource"] == "posts":
             if url["pk"]:
-                response = Post().delete_a_post(int(url["pk"]))
+                response = Post().delete_a_post(url["pk"])
                 return self.response("", status.HTTP_200_SUCCESS)
             else:
                 return self.response("", status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA)

--- a/views/posts.py
+++ b/views/posts.py
@@ -140,3 +140,18 @@ class Post:
             query_result_as_dict = dict(query_result)
             query_result_as_json = json.dumps(query_result_as_dict)
             return query_result_as_json
+        
+    def delete_a_post(self, primary_key):
+        with sqlite3.connect("./db.sqlite3") as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute(
+                """
+                DELETE FROM Posts
+                WHERE id = ? 
+                """, (primary_key,)
+            )
+
+            number_of_row_deleted = db_cursor.rowcount
+            return True if number_of_row_deleted > 0 else False


### PR DESCRIPTION
**What**
This is the back-end support for making a deletion in the database.

**Why**
Currently, our web application does not support the HTTP command, DELETE, at all. This issue ticket is one of the first requirements of the customer that relies on this deletion process. The changes made in this pull request allow the command to operate and remove posts in the database.

**How can I test this?**
1. Ensure that your server is running
2. Open Postman
3. Switch HTTP command to DELETE
4. The URL endpoint is `http://localhost:8088/posts/int`
5. The int at the endpoint is the primary key of a database entry (it specifies which post to be deleted)
6. Run the request
7. Try to get that post by using query parameters, `http://localhost:8088/posts/?post_id=int`
8. You will not see a response body for this GET command, if you try to select the post that you have deleted. 

**Files Changed**
Changed: `server.py` (lines 129 - 136) Adds DELETE support. Adds conditional to check if there is a primary key before deletion
Changed: `views/posts.py` (144 - 157) New method with SQL query to delete post based on given primary key