### PR TITLE
Added DELETE support for subscription relationships

### DIFF
--- a/server.py
+++ b/server.py
@@ -162,6 +162,10 @@ class RareApi(RequestHandler):
         """Handle DELETE requests from client"""
         url = self.parse_url(self.path)
 
+        content_len = int(self.headers.get("content-length", 0))
+        request_body = self.rfile.read(content_len)
+        request = json.loads(request_body.decode("UTF-8"))
+
         if url["requested_resource"] == "posts":
             if url["pk"]:
                 response = Post().delete_a_post(url["pk"])
@@ -172,6 +176,11 @@ class RareApi(RequestHandler):
             if url["pk"]:
                 response = Comment().delete_a_comment(url["pk"])
                 return self.response("", status.HTTP_200_SUCCESS)
+        elif url["requested_resource"] == "subscriptions":
+            response = Subscription().unsubscribe(request)
+            if response:
+                return self.response("Deleted",status.HTTP_200_SUCCESS)
+            return self.response("Do better, try harder.", status.HTTP_418_CLIENT_ERROR_IM_A_TEAPOT)
         else:
             return self.response("", status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA)
         return self.response(

--- a/views/subscriptions.py
+++ b/views/subscriptions.py
@@ -53,3 +53,23 @@ class Subscription():
                     datetime.now(),
                 ),
             )
+    def unsubscribe(self, subscription):
+        """
+        Removes a subscription relationship from the database
+        Args:
+            dictionary: a key/value pair, one representing the follower and the other the author in a relationship
+        """
+        with sqlite3.connect("./db.sqlite3") as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute(
+                """
+                DELETE FROM Subscriptions
+                WHERE follower_id = ? AND author_id = ?""", 
+                (subscription["follower_id"], subscription["author_id"]),
+            )
+
+            number_of_rows_deleted = db_cursor.rowcount
+
+            return True if number_of_rows_deleted > 0 else False


### PR DESCRIPTION
# **What**
Currently, our users have the ability to subscribe to a user. This modifies the subscribing user's subscription feed. 

# **Why**
The fact that a user can subscribe cannot then unsubscribe from the same, is an issue. When we talk about subscribing, it is an idea that a user is interested in that author's posts. Over time, this interest may be lost and they wish to no longer see these posts from that user; this feature allows that experience.

# **How can I test this?**
1. Ensure that you server is running.
2. Switch `HTTP` command to `DELETE` 
3. Create a request body following this pattern
```bash
{
    "follower_id": 1,
    "author_id": 2
}
```
5. Send the request
6 The relationship has been deleted.

# **Files Changed**
Changed: `server.py` Lines 179 - 183. A new endpoint for the DELETE method to check. This is where the request body will be processed.
Changed: `views/subscriptions.py` Lines 62 - 75. The SQL query that will execute the relationship deletion. 